### PR TITLE
Add ESLint SARIF results upload and formatter to workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,6 +68,5 @@ jobs:
         with:
           name: extension
           path: '*.vsix'
-            name: Release Extension
       
       

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
         run: npm run lint
 
       - name: Upload eslint results code scanning
-        uses: github/codeql-action/upload-sarif@v2
+        uses: github/codeql-action/upload-sarif@v3
         if: always() && github.actor != 'dependabot[bot]'
         with:
           category: eslint

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,6 +36,12 @@ jobs:
       - name: Run Linting
         run: npm run lint
 
+      - name: Upload eslint results code scanning
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          category: eslint
+          sarif_file: eslint.sarif
+
       - name: Run tests Linux
         run: xvfb-run -a npm test
         if: runner.os == 'Linux'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,8 @@ jobs:
         run: npm run lint
 
       - name: Upload eslint results code scanning
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@v2
+        if: always() && github.actor != 'dependabot[bot]'
         with:
           category: eslint
           sarif_file: eslint.sarif

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 .vscode-test/
 *.vsix
 coverage/
+*.sarif

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "tspascoal-copilot-chat-parrot",
       "version": "0.0.9",
       "devDependencies": {
+        "@microsoft/eslint-formatter-sarif": "^3.1.0",
         "@types/mocha": "^10.0.7",
         "@types/node": "20.x",
         "@types/sinon": "^17.0.3",
@@ -647,6 +648,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@microsoft/eslint-formatter-sarif": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@microsoft/eslint-formatter-sarif/-/eslint-formatter-sarif-3.1.0.tgz",
+      "integrity": "sha512-/mn4UXziHzGXnKCg+r8HGgPy+w4RzpgdoqFuqaKOqUVBT5x2CygGefIrO4SusaY7t0C4gyIWMNu6YQT6Jw64Cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "eslint": "^8.9.0",
+        "jschardet": "latest",
+        "lodash": "^4.17.14",
+        "utf8": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -3082,6 +3099,16 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jschardet": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/jschardet/-/jschardet-3.1.4.tgz",
+      "integrity": "sha512-/kmVISmrwVwtyYU40iQUOp3SUPk2dhNCMsZBQX0R1/jZ8maaXJ/oZIzUOiyOqcgtLnETFKYChbJ5iDC/eWmFHg==",
+      "dev": true,
+      "license": "LGPL-2.1+",
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -5151,6 +5178,13 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/utf8": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/utf8/-/utf8-3.0.0.tgz",
+      "integrity": "sha512-E8VjFIQ/TyQgp+TZfS6l8yp/xWppSAHzidGiRrqe4bK4XP9pTRyKFgGJpO3SN7zdX4DeomTrwaseCHovfpFcqQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/util-deprecate": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -80,10 +80,11 @@
     "watch-tests": "tsc -p . -w --outDir out",
     "pretest": "npm run compile-tests && npm run compile && npm run lint",
     "check-types": "tsc --noEmit",
-    "lint": "eslint src --ext ts",
+    "lint": "eslint src --ext ts -f @microsoft/eslint-formatter-sarif -o eslint.sarif",
     "test": "vscode-test"
   },
   "devDependencies": {
+    "@microsoft/eslint-formatter-sarif": "^3.1.0",
     "@types/mocha": "^10.0.7",
     "@types/node": "20.x",
     "@types/sinon": "^17.0.3",


### PR DESCRIPTION
This pull request introduces improvements to the linting process by integrating SARIF format for ESLint results and uploading them for code scanning. The key changes include modifications to the GitHub Actions workflow and updates to the `package.json` file.

Enhancements to linting process:

* Updated the `lint` script in `package.json` to use the SARIF formatter and output the results to `eslint.sarif`. Also added `@microsoft/eslint-formatter-sarif` as a development dependency.
* Added a new step in the GitHub Actions workflow (`.github/workflows/main.yml`) to upload the ESLint results in SARIF format using `github/codeql-action/upload-sarif@v4`.

