### PR TITLE
Update model family handling in getModelFamily function to use official method to determine user selected model

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tspascoal-copilot-chat-parrot",
-  "version": "0.0.9",
+  "version": "0.0.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tspascoal-copilot-chat-parrot",
-      "version": "0.0.9",
+      "version": "0.0.11",
       "devDependencies": {
         "@microsoft/eslint-formatter-sarif": "^3.1.0",
         "@types/mocha": "^10.0.7",
@@ -803,9 +803,9 @@
       "license": "MIT"
     },
     "node_modules/@types/vscode": {
-      "version": "1.94.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.94.0.tgz",
-      "integrity": "sha512-UyQOIUT0pb14XSqJskYnRwD2aG0QrPVefIfrW1djR+/J4KeFQ0i1+hjZoaAmeNf3Z2jleK+R2hv+EboG/m8ruw==",
+      "version": "1.96.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.96.0.tgz",
+      "integrity": "sha512-qvZbSZo+K4ZYmmDuaodMbAa67Pl6VDQzLKFka6rq+3WUTY4Kro7Bwoi0CuZLO/wema0ygcmpwow7zZfPJTs5jg==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tspascoal-copilot-chat-parrot",
   "displayName": "Parrot",
   "description": "Parrot is a chat participant that repeats things",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "repository": {
     "type": "git",
     "url": "https://github.com/tspascoal/copilot-chat-parrot-extension.git"

--- a/src/parrotchathandler.ts
+++ b/src/parrotchathandler.ts
@@ -173,12 +173,12 @@ export function getCurrentSelectionLocation(): vscode.Location | vscode.Uri | nu
  * @returns A tuple where the first element is the model name and the second element is the modified prompt.
  *
  */
-export function getModelFamily(request: any): string {
-    // Request should be vscode.ChatRequest but userSelectedModel is not in the type definition yet
-
-    if (request.userSelectedModel) {
-        return request.userSelectedModel.family;
+export function getModelFamily(request: vscode.ChatRequest): string {
+    if (request.model) {
+        return request.model.family;
     } else {
+        // This should only happen on old vscode versions that didn't 
+        // supported the picker yet
         return 'gpt-4o-mini';
     }
 }

--- a/src/test/parrotchathandler.test.ts
+++ b/src/test/parrotchathandler.test.ts
@@ -3,41 +3,35 @@ import { addReferencesToResponse, generateLikeSystemPrompt, getModelFamily, getU
 import * as vscode from 'vscode';
 import * as sinon from 'sinon';
 
+function getMockedRequest (family: string, id: string) : vscode.ChatRequest  {
+    return {
+        model: {
+            family: family,
+            id: id,
+            name: family,
+            vendor: 'copilot',
+            version: '',
+            maxInputTokens: 0,
+            sendRequest: function (messages: vscode.LanguageModelChatMessage[], options?: vscode.LanguageModelChatRequestOptions, token?: vscode.CancellationToken): Thenable<vscode.LanguageModelChatResponse> {
+                throw new Error('Function not implemented.');
+            },
+            countTokens: function (text: string | vscode.LanguageModelChatMessage, token?: vscode.CancellationToken): Thenable<number> {
+                throw new Error('Function not implemented.');
+            }
+        },
+        prompt: '',
+        command: '',
+        references: [],
+        toolReferences: [],
+        toolInvocationToken: (undefined as never)
+    }
+}
+
 suite('getModelFamily Test Suite', () => {
     test('Returns user selected model family if present', () => {
-        const request = {
-            userSelectedModel: {
-                family: 'gpt-3'
-            }
-        };
+        const request = getMockedRequest('gpt-3', 'gpt-3') ;
         const result = getModelFamily(request);
         assert.strictEqual(result, 'gpt-3');
-    });
-
-    test('Returns default model family if user selected model is not present', () => {
-        const request = {};
-        const result = getModelFamily(request);
-        assert.strictEqual(result, 'gpt-4o-mini');
-    });
-
-    test('Returns default model family if user selected model is undefined', () => {
-        const request = { userSelectedModel: undefined };
-        const result = getModelFamily(request);
-        assert.strictEqual(result, 'gpt-4o-mini');
-    });
-});
-
-suite('getModelFamily Test Suite', () => {
-    test('Returns default model family if userSelectedModel is null', () => {
-        const request = { userSelectedModel: null };
-        const result = getModelFamily(request);
-        assert.strictEqual(result, 'gpt-4o-mini');
-    });
-
-    test('Returns user selected model family if userSelectedModel.family is a non-empty string', () => {
-        const request = { userSelectedModel: { family: 'gpt-3.5' } };
-        const result = getModelFamily(request);
-        assert.strictEqual(result, 'gpt-3.5');
     });
 });
 


### PR DESCRIPTION
This pull request includes updates to the `package.json` file and modifications to the `getModelFamily` function and its associated tests in `src/parrotchathandler.ts` and `src/test/parrotchathandler.test.ts`. 
### Version Update:
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L5-R5): Updated the package version from `0.0.10` to `0.0.11`.

### Function Refactoring:
* [`src/parrotchathandler.ts`](diffhunk://#diff-e1fbccd575704bbcf9c15853296087b0ebc269834c31fb7c93a23b393a237c6cL176-R181): Refactored the `getModelFamily` function to use the `vscode.ChatRequest` type and updated the logic to check for `model` instead of `userSelectedModel`.

### Test Suite Improvements:
* [`src/test/parrotchathandler.test.ts`](diffhunk://#diff-135a0196b37284ed9e0204c9d315f3f96644996c6c40e89f215581296dccb562L6-R34): Refactored tests for `getModelFamily` by introducing a `getMockedRequest` helper function to create mock requests, and updated tests to use this helper function. Removed outdated tests related to `userSelectedModel`.